### PR TITLE
Update the release branch with our changes to the kserve fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ bin
 # Notebook Checkpoints
 .ipynb_checkpoints
 
-.gitlab-ci.yml
 .openapi-generator-ignore
 .openapi-generator/
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,60 @@
+include:
+  - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
+    ref: &include_ref 'v3'
+    file: 'environments/devex.yml'
+  - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
+    ref: *include_ref
+    file: '/blocks/python.yml'
+
+variables:
+  PY_LIBRARY_NAME: "zillow-kserve"
+  MAJOR_VERSION: "0"
+  MINOR_VERSION: "7"
+  KSERVE_VERSION_PATH: "python/kserve/setup.py"
+  PUBLISH: "true"
+
+stages:
+  - build
+
+.version: &version |
+  # Extract the open source KServe version as the basis for our forked library version.
+  KSERVE_VERSION=$(cat $KSERVE_VERSION_PATH | sed -nr "s/^ *version=['\"]([^'\"]*)['\"],/\1/p")
+
+  PY_LIBRARY_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${CI_PIPELINE_IID}"
+  if [ "${CI_COMMIT_BRANCH}" != "${CI_DEFAULT_BRANCH}" ]; then
+    PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}-dev.${CI_PIPELINE_IID}"
+    # Ensure the image tag is compliant with PEP-440,
+    IMAGE_TAG="${PY_LIBRARY_VERSION}.dev${CI_PIPELINE_IID}"
+  else
+    IMAGE_TAG="${PY_LIBRARY_VERSION}"
+  fi
+  # Only apply the KServe version to the python library as Docker versions do not have the concept of
+  # build metadata and the "+" character causes errors.
+  PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}+${KSERVE_VERSION}"
+
+build:publish:
+  extends: .aip_python_debian_image
+  stage: build
+  script:
+  - *version
+  # Now write back the zillow-kserve version back to the original location we found the original so
+  # python package managers can reference it as they need the version stored internally.
+  - sed -i "s/\(version=['\"]\)[^'\"]*\(['\"]\)/\1${PY_LIBRARY_VERSION}\2/" $KSERVE_VERSION_PATH
+  - cd python/kserve
+  - python setup.py sdist
+  # Set up the configuration for Artifactory to publish the python package internally.
+  - |
+    cat >~/.pypirc <<EOL
+    [distutils]
+    index-servers = local
+    [local]
+    repository: ${ANALYTICS_PYPI_REPOSITORY}
+    username: ${PYPI_USERNAME}
+    password: ${PYPI_PASSWORD}
+    EOL
+  - python setup.py sdist upload --repository "${ANALYTICS_PYPI_REPOSITORY}"
+  rules:
+    - if: '$PUBLISH == "true"'
+    # only trigger on zillow/ branches
+    - if: '$CI_COMMIT_BRANCH =~ /^zillow.*/'
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,22 +20,16 @@ stages:
 .version: &version |
   # Extract the open source KServe version as the basis for our forked library version.
   KSERVE_VERSION=$(cat python/VERSION)
-  echo Kserve version is $KSERVE_VERSION
 
   PY_LIBRARY_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${CI_PIPELINE_IID}"
-  echo Base PY_LIBRARY_VERSION is $PY_LIBRARY_VERSION
   if [ "${CI_COMMIT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
     PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}.dev${CI_PIPELINE_IID}"
-    # Ensure the image tag is compliant with PEP-440,
-    IMAGE_TAG="${PY_LIBRARY_VERSION}.dev${CI_PIPELINE_IID}"
-  else
-    IMAGE_TAG="${PY_LIBRARY_VERSION}"
   fi
-  echo IMAGE_TAG is $IMAGE_TAG
-  # Only apply the KServe version to the python library as Docker versions do not have the concept of
-  # build metadata and the "+" character causes errors.
+  IMAGE_TAG="${PY_LIBRARY_VERSION}"
+  
+  # Suffix the KServe version to the python library version only, because Docker versions 
+  # do not have the concept of build metadata and the "+" character causes errors.
   PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}+${KSERVE_VERSION}"
-  echo Final PY_LIBRARY_VERSION is $PY_LIBRARY_VERSION
 
 build:publish:
   extends: .aip_python_debian_image
@@ -44,7 +38,8 @@ build:publish:
   - *version
   # Now write back the zillow-kserve version back to the original location we found the original so
   # python package managers can reference it as they need the version stored internally.
-  - sed -i "s/version=version/version=\'${PY_LIBRARY_VERSION}\'/" $KSERVE_VERSION_PATH
+  # - sed -i "s/version=version/version=\'${PY_LIBRARY_VERSION}\'/" $KSERVE_VERSION_PATH -- TODO remove?
+  - echo "${PY_LIBRARY_VERSION}" > python/VERSION
   - cd python/kserve
   - python setup.py sdist
   # Set up the configuration for Artifactory to publish the python package internally.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,6 @@ stages:
   if [ "${CI_COMMIT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
     PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}.dev${CI_PIPELINE_IID}"
   fi
-  IMAGE_TAG="${PY_LIBRARY_VERSION}"
   
   # Suffix the KServe version to the python library version only, because Docker versions 
   # do not have the concept of build metadata and the "+" character causes errors.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ build:publish:
   - *version
   # Now write back the zillow-kserve version back to the original location we found the original so
   # python package managers can reference it as they need the version stored internally.
-  - sed -i "s/version=version/version=${PY_LIBRARY_VERSION}/" $KSERVE_VERSION_PATH
+  - sed -i "s/version=version/version=\'${PY_LIBRARY_VERSION}\'/" $KSERVE_VERSION_PATH
   - cd python/kserve
   - python setup.py sdist
   # Set up the configuration for Artifactory to publish the python package internally.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,10 +20,10 @@ stages:
 .version: &version |
   # Extract the open source KServe version as the basis for our forked library version.
   KSERVE_VERSION=$(cat python/VERSION)
-  echo 'Kserve version is $KSERVE_VERSION'
+  echo Kserve version is $KSERVE_VERSION
 
   PY_LIBRARY_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${CI_PIPELINE_IID}"
-  echo 'Base PY_LIBRARY_VERSION is $PY_LIBRARY_VERSION'
+  echo Base PY_LIBRARY_VERSION is $PY_LIBRARY_VERSION
   if [ "${CI_COMMIT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
     # TODO Use . instead of . anyways ?
     PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}-dev.${CI_PIPELINE_IID}"
@@ -32,11 +32,11 @@ stages:
   else
     IMAGE_TAG="${PY_LIBRARY_VERSION}"
   fi
-  echo 'IMAGE_TAG is $IMAGE_TAG'
+  echo IMAGE_TAG is $IMAGE_TAG
   # Only apply the KServe version to the python library as Docker versions do not have the concept of
   # build metadata and the "+" character causes errors.
   PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}+${KSERVE_VERSION}"
-  echo 'Final PY_LIBRARY_VERSION is $PY_LIBRARY_VERSION'
+  echo Final PY_LIBRARY_VERSION is $PY_LIBRARY_VERSION
 
 build:publish:
   extends: .aip_python_debian_image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ build:publish:
   - *version
   # Now write back the zillow-kserve version back to the original location we found the original so
   # python package managers can reference it as they need the version stored internally.
-  - sed -i "s/version=version/version=\${PY_LIBRARY_VERSION}/" $KSERVE_VERSION_PATH
+  - sed -i "s/version=version/version=${PY_LIBRARY_VERSION}/" $KSERVE_VERSION_PATH
   - cd python/kserve
   - python setup.py sdist
   # Set up the configuration for Artifactory to publish the python package internally.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,9 @@
 include:
   - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
-    ref: &include_ref 'v3' # TODO use v4?
+    ref: &include_ref 'v3'
     file: 'environments/devex.yml'
   - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
-    ref: *include_ref
+    ref: *include_ref # TODO Use V4?
     file: '/blocks/python.yml'
 
 variables:
@@ -45,7 +45,7 @@ build:publish:
   - *version
   # Now write back the zillow-kserve version back to the original location we found the original so
   # python package managers can reference it as they need the version stored internally.
-  - sed -i "s/\(version=['\"]\)[^'\"]*\(['\"]\)/\1${PY_LIBRARY_VERSION}\2/" $KSERVE_VERSION_PATH
+  - sed -i "s/version=version/version=\${PY_LIBRARY_VERSION}/" $KSERVE_VERSION_PATH
   - cd python/kserve
   - python setup.py sdist
   # Set up the configuration for Artifactory to publish the python package internally.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 include:
   - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
-    ref: &include_ref 'v3'
+    ref: &include_ref 'v3' # TODO use v4?
     file: 'environments/devex.yml'
   - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
     ref: *include_ref
@@ -9,7 +9,8 @@ include:
 variables:
   PY_LIBRARY_NAME: "zillow-kserve"
   MAJOR_VERSION: "0"
-  MINOR_VERSION: "7"
+  MINOR_VERSION: "10"
+  RELEASE_BRANCH: "zillow/release-0.10.2"
   KSERVE_VERSION_PATH: "python/kserve/setup.py"
   PUBLISH: "true"
 
@@ -18,10 +19,11 @@ stages:
 
 .version: &version |
   # Extract the open source KServe version as the basis for our forked library version.
-  KSERVE_VERSION=$(cat $KSERVE_VERSION_PATH | sed -nr "s/^ *version=['\"]([^'\"]*)['\"],/\1/p")
+  KSERVE_VERSION=$(cat python/VERSION)
 
   PY_LIBRARY_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${CI_PIPELINE_IID}"
-  if [ "${CI_COMMIT_BRANCH}" != "${CI_DEFAULT_BRANCH}" ]; then
+  if [ "${CI_COMMIT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
+    # TODO Use . instead of . anyways ?
     PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}-dev.${CI_PIPELINE_IID}"
     # Ensure the image tag is compliant with PEP-440,
     IMAGE_TAG="${PY_LIBRARY_VERSION}.dev${CI_PIPELINE_IID}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,9 @@
 include:
   - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
-    ref: &include_ref 'v3'
+    ref: &include_ref 'v4'
     file: 'environments/devex.yml'
   - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
-    ref: *include_ref # TODO Use V4?
+    ref: *include_ref
     file: '/blocks/python.yml'
 
 variables:
@@ -36,9 +36,8 @@ build:publish:
   stage: build
   script:
   - *version
-  # Now write back the zillow-kserve version back to the original location we found the original so
-  # python package managers can reference it as they need the version stored internally.
-  # - sed -i "s/version=version/version=\'${PY_LIBRARY_VERSION}\'/" $KSERVE_VERSION_PATH -- TODO remove?
+  # Now write back the zillow-kserve version back to the original location we got it from,
+  # so python package managers can reference it as they need the version stored internally.
   - echo "${PY_LIBRARY_VERSION}" > python/VERSION
   - cd python/kserve
   - python setup.py sdist

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,8 +25,7 @@ stages:
   PY_LIBRARY_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${CI_PIPELINE_IID}"
   echo Base PY_LIBRARY_VERSION is $PY_LIBRARY_VERSION
   if [ "${CI_COMMIT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
-    # TODO Use . instead of . anyways ?
-    PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}-dev.${CI_PIPELINE_IID}"
+    PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}.dev${CI_PIPELINE_IID}"
     # Ensure the image tag is compliant with PEP-440,
     IMAGE_TAG="${PY_LIBRARY_VERSION}.dev${CI_PIPELINE_IID}"
   else

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,8 +20,10 @@ stages:
 .version: &version |
   # Extract the open source KServe version as the basis for our forked library version.
   KSERVE_VERSION=$(cat python/VERSION)
+  echo 'Kserve version is $KSERVE_VERSION'
 
   PY_LIBRARY_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${CI_PIPELINE_IID}"
+  echo 'Base PY_LIBRARY_VERSION is $PY_LIBRARY_VERSION'
   if [ "${CI_COMMIT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
     # TODO Use . instead of . anyways ?
     PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}-dev.${CI_PIPELINE_IID}"
@@ -30,9 +32,11 @@ stages:
   else
     IMAGE_TAG="${PY_LIBRARY_VERSION}"
   fi
+  echo 'IMAGE_TAG is $IMAGE_TAG'
   # Only apply the KServe version to the python library as Docker versions do not have the concept of
   # build metadata and the "+" character causes errors.
   PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}+${KSERVE_VERSION}"
+  echo 'Final PY_LIBRARY_VERSION is $PY_LIBRARY_VERSION'
 
 build:publish:
   extends: .aip_python_debian_image
@@ -59,4 +63,3 @@ build:publish:
     - if: '$PUBLISH == "true"'
     # only trigger on zillow/ branches
     - if: '$CI_COMMIT_BRANCH =~ /^zillow.*/'
-

--- a/python/kserve/kserve/storage.py
+++ b/python/kserve/kserve/storage.py
@@ -32,9 +32,16 @@ from azure.storage.blob import BlobServiceClient
 from azure.storage.blob._list_blobs_helper import BlobPrefix
 from azure.storage.fileshare import ShareServiceClient
 
-from botocore.client import Config
-from botocore import UNSIGNED
-import boto3
+# AIP: we'll never use them
+try:
+    from botocore.client import Config
+    from botocore import UNSIGNED
+    import boto3
+except ImportError:
+    Config = None
+    UNSIGNED = None
+    boto3 = None
+
 from google.auth import exceptions
 from google.cloud import storage
 

--- a/python/kserve/requirements.txt
+++ b/python/kserve/requirements.txt
@@ -14,9 +14,11 @@ azure-storage-file-share==12.7.0
 azure-identity>=1.8.0
 cloudevents>=1.6.2
 avro>=1.11.0
-boto3~=1.21
+# AIP: remove boto dependencies as we are not using them and they will slow down dependency resolution
+# boto3~=1.21
 psutil>=5.9.0
-ray[serve]==2.0.0
+# AIP: relax ray for vllm
+ray[serve]>=2.0.0
 grpcio>=1.34.0
 tritonclient==2.18.0
 protobuf>=3.19.0

--- a/python/kserve/setup.py
+++ b/python/kserve/setup.py
@@ -31,7 +31,7 @@ with open(pathlib.Path(__file__).parent.parent / 'VERSION') as version_file:
     version = version_file.read().strip()
 
 setuptools.setup(
-    name='kserve',
+    name='zillow-kserve',
     version=version,
     author="The KServe Authors",
     author_email='ellisbigelow@google.com, hejinchi@cn.ibm.com, dsun20@bloomberg.net',


### PR DESCRIPTION
This MR updates the release branch with our changes to the kserve fork. 

Changes:
* Ported the changes from the `zillow/kserve` branch.
* Updated the logic in gitlab-ci.yaml as the logic to identify the version has changed a little in the open source code. You can see those changes with [the diff of the first and the last commit](https://github.com/zillow/kserve/pull/6/files/fb1cf952d85fd7ce06c2cc370344b40d612708d5..efbe5f03f35cb2fcc83014e57ab02055d901a42f ) to this branch. Confirmed that the version number is being [generated](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/sdks/internal/zillow-kserve/-/jobs/33026693#L488) as expected.

If there any other changes needed to the fork, a separate MR will be created.
