### PR TITLE
remove argparse

### DIFF
--- a/python/kserve/requirements.txt
+++ b/python/kserve/requirements.txt
@@ -5,7 +5,8 @@ setuptools>=21.0.0
 urllib3>=1.15.1
 kubernetes>=12.0.0
 tornado>=6.0.0
-argparse>=1.4.0
+# AIP: Removing as it breaks Py3.10 pytest. argparse is also now in the standard library in >= Py3.2
+# argparse>=1.4.0
 minio>=4.0.9,<7.0.0
 google-cloud-storage==1.41.1
 adal>=1.2.2


### PR DESCRIPTION
argparse breaks pytest in Python 3.10.  Removing as it is in Python stdlib since Python 3.2
